### PR TITLE
fix: prevent locked users from making requests to server

### DIFF
--- a/backend/src/middleware/isAdmin.ts
+++ b/backend/src/middleware/isAdmin.ts
@@ -1,12 +1,8 @@
 import { type TokenPayload } from 'treasure-trove-shared';
 import { User } from '../db/models/user.ts';
-import { requireAuth } from './jwt.ts';
-import type { Request, Response, NextFunction } from 'express';
-
-// Extend Express Request type to include `auth`
-export interface AuthenticatedRequest extends Request {
-  auth?: TokenPayload;
-}
+import type { Response, NextFunction } from 'express';
+import type { AuthenticatedRequest } from './types.ts';
+import { userFullAuth } from './userAuth.ts';
 
 export async function checkAdmin(
   auth: TokenPayload | undefined,
@@ -25,7 +21,7 @@ export async function checkAdmin(
 
 export const isAdmin = [
   // no redundant code...admin is a layer on top of JWT auth
-  requireAuth,
+  userFullAuth,
   async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
     try {
       const valid = await checkAdmin(req.auth);

--- a/backend/src/middleware/types.ts
+++ b/backend/src/middleware/types.ts
@@ -1,0 +1,7 @@
+import { TokenPayload } from 'treasure-trove-shared';
+import type { Request } from 'express';
+
+// Extend Express Request type to include `auth`
+export interface AuthenticatedRequest extends Request {
+  auth?: TokenPayload;
+}

--- a/backend/src/middleware/userAuth.ts
+++ b/backend/src/middleware/userAuth.ts
@@ -1,0 +1,40 @@
+import type { Response, NextFunction } from 'express';
+import { User } from '../db/models/user.ts';
+import { type TokenPayload } from 'treasure-trove-shared';
+import { requireAuth } from './jwt.ts';
+import type { AuthenticatedRequest } from './types.ts';
+
+async function checkIsLocked(auth: TokenPayload | undefined): Promise<number> {
+  // First verify token has proper parameters.
+  if (!auth) return 404;
+  if (auth!.sub === undefined) return 403;
+
+  // If it does, make sure the user is not locked out of the platform.
+  const user = await User.findById(auth!.sub);
+  if (!user) return 404;
+  if (user.locked) return 403;
+
+  return 200;
+}
+
+export const userFullAuth = [
+  requireAuth,
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+      const valid = await checkIsLocked(req.auth);
+      switch (valid) {
+        case 404:
+          return res.status(404).json({ error: 'User not found' });
+        case 403:
+          return res
+            .status(403)
+            .json({ error: 'Access denied: user is locked out' });
+        case 200:
+          next();
+      }
+    } catch (err) {
+      console.error('User-lock check failed:', err);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+];

--- a/backend/src/routes/auctions.ts
+++ b/backend/src/routes/auctions.ts
@@ -1,6 +1,5 @@
 import express from 'express';
 import type { Request, Response } from 'express';
-import { requireAuth } from '../middleware/jwt.ts';
 import AuctionsService from '../services/auctions.ts';
 import {
   createAuctionSchema,
@@ -8,11 +7,12 @@ import {
   updateAuctionSchema,
 } from 'treasure-trove-shared';
 import BidsService from '../services/bids.ts';
+import { userFullAuth } from 'src/middleware/userAuth.ts';
 
 const auctionsRouter = express.Router();
 
 // GET information about all auctions.
-auctionsRouter.get('/', requireAuth, async (_req: Request, res: Response) => {
+auctionsRouter.get('/', userFullAuth, async (_req: Request, res: Response) => {
   try {
     const auctions = await AuctionsService.getAllAuctions();
     res.status(200).json(auctions);
@@ -23,18 +23,22 @@ auctionsRouter.get('/', requireAuth, async (_req: Request, res: Response) => {
 });
 
 // GET information about the auction with the given ID.
-auctionsRouter.get('/:id', requireAuth, async (req: Request, res: Response) => {
-  try {
-    const auctionInfo = await AuctionsService.getAuctionById(req.params.id);
-    return res.status(200).json(auctionInfo);
-  } catch (error) {
-    console.error('Error fetching auction info:', error);
-    return res.status(404).json({ error: 'Auction not found' });
-  }
-});
+auctionsRouter.get(
+  '/:id',
+  userFullAuth,
+  async (req: Request, res: Response) => {
+    try {
+      const auctionInfo = await AuctionsService.getAuctionById(req.params.id);
+      return res.status(200).json(auctionInfo);
+    } catch (error) {
+      console.error('Error fetching auction info:', error);
+      return res.status(404).json({ error: 'Auction not found' });
+    }
+  },
+);
 
 // POST endpoint to create a new auction.
-auctionsRouter.post('/', requireAuth, async (req: Request, res: Response) => {
+auctionsRouter.post('/', userFullAuth, async (req: Request, res: Response) => {
   try {
     const validatedBody = createAuctionSchema.validateSync(req.body);
     const auction = await AuctionsService.createAuction(validatedBody);
@@ -49,25 +53,29 @@ auctionsRouter.post('/', requireAuth, async (req: Request, res: Response) => {
 });
 
 // PUT endpoint to update information about an existing auction.
-auctionsRouter.put('/:id', requireAuth, async (req: Request, res: Response) => {
-  try {
-    const validatedBody = updateAuctionSchema.validateSync(req.body);
-    const auctionInfo = await AuctionsService.updateAuction(
-      req.params.id,
-      validatedBody,
-    );
-    return res.status(200).json(auctionInfo);
-  } catch (error) {
-    console.error('Error updating auction:', error);
-    // Use 400 when there is a bad request for some reason.
-    return res.status(400).json({ error: 'failed to update auction ' });
-  }
-});
+auctionsRouter.put(
+  '/:id',
+  userFullAuth,
+  async (req: Request, res: Response) => {
+    try {
+      const validatedBody = updateAuctionSchema.validateSync(req.body);
+      const auctionInfo = await AuctionsService.updateAuction(
+        req.params.id,
+        validatedBody,
+      );
+      return res.status(200).json(auctionInfo);
+    } catch (error) {
+      console.error('Error updating auction:', error);
+      // Use 400 when there is a bad request for some reason.
+      return res.status(400).json({ error: 'failed to update auction ' });
+    }
+  },
+);
 
 // GET all the bids associated with a given auction.
 auctionsRouter.get(
   '/:id/bids',
-  requireAuth,
+  userFullAuth,
   async (req: Request, res: Response) => {
     try {
       const bidsInfo = await BidsService.getAuctionBids(req.params.id);
@@ -82,7 +90,7 @@ auctionsRouter.get(
 // POST endpoint to create a new bid for the given auction.
 auctionsRouter.post(
   '/:id/bids',
-  requireAuth,
+  userFullAuth,
   async (req: Request, res: Response) => {
     try {
       const validatedBody = createBidSchema.validateSync(req.body);
@@ -101,7 +109,7 @@ auctionsRouter.post(
 // DELETE an auction.
 auctionsRouter.delete(
   '/:id',
-  requireAuth,
+  userFullAuth,
   async (req: Request, res: Response) => {
     try {
       await AuctionsService.deleteAuction(req.params.id);

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -1,16 +1,14 @@
 import express from 'express';
 import type { Request, Response } from 'express';
 import UsersService from '../services/users.ts';
-import { requireAuth } from '../middleware/jwt.ts';
 import {
   fullUserInfoSchema,
   regularUserInfoSchema,
   userCredentialsSchema,
 } from 'treasure-trove-shared';
-import {
-  type AuthenticatedRequest,
-  checkAdmin,
-} from '../middleware/isAdmin.ts';
+import { checkAdmin } from '../middleware/isAdmin.ts';
+import { userFullAuth } from '../middleware/userAuth.ts';
+import { type AuthenticatedRequest } from '../middleware/types.ts';
 
 const usersRouter = express.Router();
 
@@ -59,7 +57,7 @@ usersRouter.post('/signup', async (req: Request, res: Response) => {
 // Admin-only fields like lock status will only be returned with admin authentication.
 usersRouter.get(
   '/:id',
-  requireAuth,
+  userFullAuth,
   async (req: AuthenticatedRequest, res: Response) => {
     try {
       // Check if the user's token has admin privileges.
@@ -88,7 +86,7 @@ usersRouter.get(
 // Changing fields like lock status requires admin authentication.
 usersRouter.put(
   '/:id',
-  requireAuth,
+  userFullAuth,
   async (req: AuthenticatedRequest, res: Response) => {
     try {
       // Check if the user's token has admin privileges.


### PR DESCRIPTION
# Changes

Added new middleware to deny backend requests from locked-out users.

# Testing

1. Open one window and log in as admin.
2. Log into a regular account.
3. Lock the regular account from the admin page.
4. Go to the "my auctions" page. Verify the request is rejected and you see an error message.